### PR TITLE
fix: package.json中的依赖的react-naitve-webview

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "peerDependencies": {
     "react": ">= 16.8.0",
     "react-native": ">= 0.60.0",
-    "@react-native-oh-tpl/react-native-webview":">= 13.6.3-0.0.1"
+    "react-native-webview":">= 13.6.3"
   },
   "dependencies": {
     "deprecated-react-native-prop-types": "^2.3.0",


### PR DESCRIPTION

# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：

- 这个 PR 解决了 closes #4 
- 将package.json中的对于react-native-webview的依赖从原来的@react-native-on-tpl/react-native-webview改为react-naitve-webview解决 安装时报错问题






## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

